### PR TITLE
Update crypto.c

### DIFF
--- a/src/crypto.c
+++ b/src/crypto.c
@@ -26,6 +26,7 @@
 #include <sys/stat.h>
 
 #include <openssl/aes.h>
+#include <openssl/modes.h>
 #include <openssl/bn.h>
 #include <openssl/err.h>
 
@@ -179,7 +180,7 @@ static int aes_128_ctr (const unsigned char key[AES_KEYSIZE_128],
   }
 
   AES_set_encrypt_key(&key[0], 128, &akey);
-  AES_ctr128_encrypt(in, out, length, &akey, iv, tmp, &num);
+  CRYPTO_ctr128_encrypt(in, out, length, &akey, iv, tmp, &num, (block128_f)AES_encrypt);
 
   return 0;
 }


### PR DESCRIPTION
Updated Crypto.c to reflect changes in openssl 1.1.0 onwards.

See this question for reference:

https://stackoverflow.com/questions/52369124/what-is-exact-alternate-api-instead-of-aes-ctr128-encrypt-from-openssl-1-1-0